### PR TITLE
allow overriding web config, fix #44

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /ocr-fileformat
 RUN apk add --no-cache openjdk8-jre php7 php7-json py-lxml git make ca-certificates wget bash \
     && update-ca-certificates \
     && make install \
+    && cp docker.config.php web/config.local.php \
     && mv web /ocr-fileformat-web \
     && rm -rf /ocr-fileformat \
     && apk del git make wget

--- a/docker.config.php
+++ b/docker.config.php
@@ -1,0 +1,3 @@
+<?php
+$config['ocr-validate'] = '/usr/local/bin/ocr-validate';
+$config['ocr-transform'] = '/usr/local/bin/ocr-transform';

--- a/web/config.php
+++ b/web/config.php
@@ -15,6 +15,11 @@ $config = array(
     ),
 );
 
+$local_settings = dirname(__FILE__) . '/config.local.php';
+if (file_exists($local_settings)) {
+  include $local_settings;
+}
+
 /**
  * List of installed transform from-to-tuples.
  * List of installed schemas.


### PR DESCRIPTION
Config settings can be overridden by providing a file `config.local.php` that can manipulate `$config`.