### PR TITLE
Add missing semicolon in escaping of backslash

### DIFF
--- a/web/ocr-fileformat.js
+++ b/web/ocr-fileformat.js
@@ -45,7 +45,7 @@ function escapeHTML(str) {
         replace(/</g, '&lt;').
         replace(/"/g, '&quot;').
         replace(/'/g, '&#39;').
-        replace(/\//g, '&#x2F').
+        replace(/\//g, '&#x2F;').
         replace(/>/g, '&gt;');
 }
 


### PR DESCRIPTION
This seems to fix the encoding problem mentioned in #60
without any other negative effect.