### PR TITLE
WIP Faster docker builds by sacrificing layer size for cacheability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,3 @@ xslt
 !xslt/alto2.0__alto3.0.xsl
 !xslt/alto2.1__alto3.0.xsl
 !xslt/alto2.1__alto3.1.xsl
-
-vendor/*
-!vendor/Makefile
-!vendor/saxon9he.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM alpine:edge
 MAINTAINER Konstantin Baierer <konstantin.baierer@gmail.com>
 
 EXPOSE 8080
+RUN apk add --no-cache openjdk8-jre php7 php7-json python py-lxml git make ca-certificates wget bash gcc libc-dev \
+    && update-ca-certificates
 COPY . /ocr-fileformat
 WORKDIR /ocr-fileformat
-RUN apk add --no-cache openjdk8-jre php7 php7-json python py-lxml git make ca-certificates wget bash gcc libc-dev \
-    && update-ca-certificates \
-    && make install \
+RUN make install \
     && cp docker.config.php web/config.local.php \
     && mv web /ocr-fileformat-web \
     && rm -rf /ocr-fileformat \


### PR DESCRIPTION
Makes it way faster to rebuild a docker image which speeds up rebuilds. For now, this PR is just to check the resulting image size on Docker Hub.