### PR TITLE
Move navbar above tab panes in web interface

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -42,6 +42,23 @@
 
           <div class="row">
 
+              <div class="col-xs-3">
+
+                <!-- Nav tabs -->
+                <ul class="nav nav-tabs nav-justified" role="tablist">
+                  <li role="presentation" class="active">
+                    <a role="tab" data-toggle="tab" href="#transform-url-tab" tabindex=-1>URL</a>
+                  </li>
+                  <li role="presentation">
+                    <a role="tab" data-toggle="tab" href="#transform-file-tab" tabindex=-1>Upload</a>
+                  </li>
+                </ul>
+
+              </div>
+          </div>
+
+          <div class="row">
+
               <div class="col-xs-6">
 
                 <!-- Tab panes -->
@@ -60,16 +77,6 @@
                       style="width:100%" />
                   </div>
                 </div>
-
-                <!-- Nav tabs -->
-                <ul class="nav nav-tabs nav-justified" role="tablist">
-                  <li role="presentation" class="active">
-                    <a role="tab" data-toggle="tab" href="#transform-url-tab" tabindex=-1>URL</a>
-                  </li>
-                  <li role="presentation">
-                    <a role="tab" data-toggle="tab" href="#transform-file-tab" tabindex=-1>Upload</a>
-                  </li>
-                </ul>
 
               </div>
 


### PR DESCRIPTION
Previous:

![navbar-now](https://user-images.githubusercontent.com/5199995/33822342-7a0db828-de57-11e7-9b48-56974ca125ad.png)

With this PR:

![navbar-move](https://user-images.githubusercontent.com/5199995/33822349-80ac1f80-de57-11e7-990f-84e4524a2f1f.png)
