### PR TITLE
Fix ignored files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,8 +6,8 @@ xsd
 
 xslt
 !xslt/alto2.0__alto3.0.xsl
-!xslt/alto2.1__alto3.0.xsl
-!xslt/alto2.1__alto3.1.xsl
+!xslt/page__text.xsl
+!xslt/tei__hocr.xsl
 
 vendor/*
 !vendor/Makefile

--- a/xslt/.gitignore
+++ b/xslt/.gitignore
@@ -1,4 +1,5 @@
 *.xml
 *.xsl
 !alto2.0__alto3.0.xsl
+!page__text.xsl
 !tei__hocr.xsl


### PR DESCRIPTION
The current docker image fails to provide the XSLT
transformations page__text and tei__hocr because
they were ignored. This commit fixes this.