### PR TITLE
[WIP] Fix page__alto and alto__page

### DIFF
--- a/bin/ocr-transform.sh
+++ b/bin/ocr-transform.sh
@@ -32,6 +32,11 @@ show_version () {
 
 #{{{ main ()
 main () {
+    # debug option -d -d to print all commands to the terminal
+    if (( DEBUG > 1 ));then
+        set -x
+    fi
+
     local from="$1" to="$2" infile='-' outfile='-' transformer
     shift 2
     declare -a script_args

--- a/script/transform/alto__page
+++ b/script/transform/alto__page
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENDORDIR="$(cd $SCRIPTDIR/../../vendor/; pwd)"
 JAR="$VENDORDIR/JPageConverter/PageConverter.jar"

--- a/script/transform/alto__page
+++ b/script/transform/alto__page
@@ -11,7 +11,7 @@ if [[ "$2" = "-" ]];then
     OUTFILE="$(mktemp)"
 fi
 
-java -jar "$JAR" -neg-coords toZero -source-xml "$INFILE" -target-xml "$OUTFILE"
+java -jar "$JAR" -neg-coords toZero -source-xml "$INFILE" -target-xml "$OUTFILE" "${@:3}"
 
 if [[ "$is_temp" = true ]];then
     cat "$OUTFILE"

--- a/script/transform/page__alto
+++ b/script/transform/page__alto
@@ -1,1 +1,2 @@
-alto__page
+#!/bin/bash
+./alto__page "$@" -convert-to ALTO


### PR DESCRIPTION
This is work in progress and I may need some help. Currently the transformations alto2page and page2alto are present but not everything is producing some reasonable output:
- In the web GUI any of these transformations leads to an empty file. I haven't found out why...
- The alto2page transformation seems to work in the CLI but the debugging messages (bash -x resp. set -x) were unusual. I tried to toggle them on only when the debug option is toggled twice. However, this then only works for the main script and will not for any otherwise called script. Can this been improved?
- The page2alto transformation in the CLI produces some output but that is again a page file. For this we need another parameter which I tried to pass now. This should be further tested and reviewed whether the approach looks reasonable for you bash script experts.

Do not yet merge this, as we need first to finish this PR together. CC @kba @stweil 