### PR TITLE
Fix conversion from ALTO to PAGE and vice versa

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Usage: ocr-transform [-dhLv] <from> <to> [<infile> [<outfile>]] [-- <script-args
 
     Transformations:
         abbyy hocr
+        abbyy page
         alto2.0 alto3.0
         alto2.0 alto3.1
         alto2.0 hocr
@@ -194,7 +195,7 @@ capable stylesheet transformer.
 | hOCR                | =    | ✓    | ✓       |
 | ALTO                | ✓    | =    | ✓       |
 | PAGEXML             | ✓    | ✓    | =       |
-| FineReader          | ✓    | -    | -       |
+| FineReader          | ✓    | -    | ✓       |
 | Google Cloud Vision | ✓    | -    | -       |
 | TEI                 | ✓    | -    | -       |
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Usage: ocr-transform [-dhLv] <from> <to> [<infile> [<outfile>]] [-- <script-args
         alto page
         alto text
         gcv hocr
+        gcv page
         hocr alto2.0
         hocr alto2.1
         hocr page
@@ -196,7 +197,7 @@ capable stylesheet transformer.
 | ALTO                | ✓    | =    | ✓       |
 | PAGEXML             | ✓    | ✓    | =       |
 | FineReader          | ✓    | -    | ✓       |
-| Google Cloud Vision | ✓    | -    | -       |
+| Google Cloud Vision | ✓    | -    | ✓       |
 | TEI                 | ✓    | -    | -       |
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Usage: ocr-transform [-dhLv] <from> <to> [<infile> [<outfile>]] [-- <script-args
         gcv hocr
         hocr alto2.0
         hocr alto2.1
+        hocr page
         hocr text
         page alto
         page hocr
@@ -190,7 +191,7 @@ capable stylesheet transformer.
 
 | From ╲ To           | hOCR | ALTO | PAGEXML |
 | ---:                | ---  | ---  | ---     |
-| hOCR                | =    | ✓    | -       |
+| hOCR                | =    | ✓    | ✓       |
 | ALTO                | ✓    | =    | ✓       |
 | PAGEXML             | ✓    | ✓    | =       |
 | FineReader          | ✓    | -    | -       |

--- a/bin/ocr-transform.sh
+++ b/bin/ocr-transform.sh
@@ -34,7 +34,6 @@ show_version () {
 main () {
     local from="$1" to="$2" infile='-' outfile='-' transformer
     shift 2
-    declare -a script_args
 
     # Validate parameters
     if [[ -z "$from" ]];then
@@ -49,6 +48,8 @@ main () {
             show_usage "No mapping from '$from' to '$to'"
         fi
     fi
+
+    declare -a script_args
 
     # <infile>
     if [[ "$1" == '--' ]];then
@@ -86,8 +87,7 @@ main () {
         [[ "$outfile" != '-' ]] &&  script_args=("${script_args[@]}" "-o:$outfile")
         exec_saxon "${script_args[@]}"
     else
-        script_args=("${script_args[@]}" "$infile")
-        script_args=("${script_args[@]}" "$outfile")
+        script_args=("$infile" "$outfile" "${script_args[@]}")
         "$transformer" "${script_args[@]}"
     fi
 }

--- a/lib.sh
+++ b/lib.sh
@@ -118,7 +118,7 @@ show_saxon_options () {
 #{{{ run saxon / xsd-validator (xsdv.sh)
 # exec_saxon ()
 exec_saxon() {
-    (( DEBUG > 0 )) && loginfo Executing "java -jar $SAXON_JAR" "$@"
+    (( DEBUG > 0 )) && loginfo Executing "java -jar $SHAREDIR/vendor/saxon9he.jar" "$@"
     (( DEBUG > 1 )) && SAXON_ARGS+=('-t')
     java -jar "$SHAREDIR/vendor/saxon9he.jar" "$@"
 }

--- a/script/transform/abbyy__page
+++ b/script/transform/abbyy__page
@@ -1,0 +1,1 @@
+alto__page

--- a/script/transform/alto__page
+++ b/script/transform/alto__page
@@ -5,6 +5,7 @@ VENDORDIR="$(cd $SCRIPTDIR/../../vendor/; pwd)"
 JAR="$VENDORDIR/JPageConverter/PageConverter.jar"
 INFILE="$1"
 OUTFILE="$2"
+ARGUMENT="$3"
 
 if [[ "$1" = "-" ]]; then
     INFILE="$(mktemp)"
@@ -22,6 +23,10 @@ if [[ "$1" = "-" ]]; then
 fi
 
 if [[ "$2" = "-" ]]; then
-    cat "$OUTFILE"
+    if [[ -z "$ARGUMENT" ]]; then
+        cat "$OUTFILE"
+    else
+        java -cp "$VENDORDIR/saxon9he.jar" net.sf.saxon.Query -s:"$OUTFILE" -qs:/ "$ARGUMENT"
+    fi
     rm "$OUTFILE"
 fi

--- a/script/transform/alto__page
+++ b/script/transform/alto__page
@@ -1,19 +1,27 @@
-#!/bin/bash -x
+#!/bin/bash
+
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENDORDIR="$(cd $SCRIPTDIR/../../vendor/; pwd)"
 JAR="$VENDORDIR/JPageConverter/PageConverter.jar"
 INFILE="$1"
 OUTFILE="$2"
 
-is_temp=
-if [[ "$2" = "-" ]];then
-    is_temp=true
+if [[ "$1" = "-" ]]; then
+    INFILE="$(mktemp)"
+    cat >"$INFILE"
+fi
+
+if [[ "$2" = "-" ]]; then
     OUTFILE="$(mktemp)"
 fi
 
-java -jar "$JAR" -neg-coords toZero -source-xml "$INFILE" -target-xml "$OUTFILE"
+java -jar "$JAR" -neg-coords toZero -source-xml "$INFILE" -target-xml "$OUTFILE" 2>&1
 
-if [[ "$is_temp" = true ]];then
+if [[ "$1" = "-" ]]; then
+    rm "$INFILE"
+fi
+
+if [[ "$2" = "-" ]]; then
     cat "$OUTFILE"
     rm "$OUTFILE"
 fi

--- a/script/transform/gcv__hocr
+++ b/script/transform/gcv__hocr
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENDORDIR="$(cd $SCRIPTDIR/../../vendor/; pwd)"
 VENDORSCRIPT="$VENDORDIR/gcv2hocr/gcv2hocr"
@@ -8,15 +9,22 @@ OUTFILE="$2"
 WIDTH=2000
 HEIGHT=2000
 
-is_temp=
-if [[ "$2" = "-" ]];then
-    is_temp=true
+if [[ "$1" = "-" ]]; then
+    INFILE="$(mktemp)"
+    cat >"$INFILE"
+fi
+
+if [[ "$2" = "-" ]]; then
     OUTFILE="$(mktemp)"
 fi
 
 "$VENDORSCRIPT" "$INFILE" "$OUTFILE" "$WIDTH" "$HEIGHT"
 
-if [[ "$is_temp" = true ]];then
+if [[ "$1" = "-" ]]; then
+    rm "$INFILE"
+fi
+
+if [[ "$2" = "-" ]]; then
     cat "$OUTFILE"
     rm "$OUTFILE"
 fi

--- a/script/transform/gcv__page
+++ b/script/transform/gcv__page
@@ -1,0 +1,1 @@
+alto__page

--- a/script/transform/hocr__page
+++ b/script/transform/hocr__page
@@ -1,0 +1,1 @@
+alto__page

--- a/script/transform/page__alto
+++ b/script/transform/page__alto
@@ -5,6 +5,7 @@ VENDORDIR="$(cd $SCRIPTDIR/../../vendor/; pwd)"
 JAR="$VENDORDIR/JPageConverter/PageConverter.jar"
 INFILE="$1"
 OUTFILE="$2"
+ARGUMENT="$3"
 
 if [[ "$1" = "-" ]]; then
     INFILE="$(mktemp)"
@@ -22,6 +23,10 @@ if [[ "$1" = "-" ]]; then
 fi
 
 if [[ "$2" = "-" ]]; then
-    cat "$OUTFILE"
+    if [[ -z "$ARGUMENT" ]]; then
+        cat "$OUTFILE"
+    else
+        java -cp "$VENDORDIR/saxon9he.jar" net.sf.saxon.Query -s:"$OUTFILE" -qs:/ "$ARGUMENT"
+    fi
     rm "$OUTFILE"
 fi

--- a/script/transform/page__alto
+++ b/script/transform/page__alto
@@ -1,1 +1,27 @@
-alto__page
+#!/bin/bash
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENDORDIR="$(cd $SCRIPTDIR/../../vendor/; pwd)"
+JAR="$VENDORDIR/JPageConverter/PageConverter.jar"
+INFILE="$1"
+OUTFILE="$2"
+
+if [[ "$1" = "-" ]]; then
+    INFILE="$(mktemp)"
+    cat >"$INFILE"
+fi
+
+if [[ "$2" = "-" ]]; then
+    OUTFILE="$(mktemp)"
+fi
+
+java -jar "$JAR" -neg-coords toZero -source-xml "$INFILE" -target-xml "$OUTFILE" -convert-to ALTO 2>&1
+
+if [[ "$1" = "-" ]]; then
+    rm "$INFILE"
+fi
+
+if [[ "$2" = "-" ]]; then
+    cat "$OUTFILE"
+    rm "$OUTFILE"
+fi


### PR DESCRIPTION
- Fix order of arguments passed
- Remove shell debugging (-x)
- Handle input from STDIN
- Add `-convert-to ALTO` argument needed for conversion from PAGE to ALTO