### PR TITLE
:arrow_up: Upgrade to new version of hOCR-to-ALTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,15 @@ xsd: vendor
 xslt: vendor
 	$(MKDIR) xslt
 	# symlink hocr<->alto as well as the language codes lookup xml
-	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/hocr2alto2.0.xsl hocr__alto2.0.xsl
-	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/hocr2alto2.1.xsl hocr__alto2.1.xsl
-	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/alto2hocr.xsl alto2.0__hocr.xsl
-	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/alto2hocr.xsl alto2.1__hocr.xsl
-	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/hocr2text.xsl hocr__text.xsl
-	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/alto2text.xsl alto__text.xsl
+	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/hocr__alto2.0.xsl hocr__alto2.0.xsl
+	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/hocr__alto2.1.xsl hocr__alto2.1.xsl
+	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/hocr__alto3.xsl hocr__alto3.0.xsl
+	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/hocr__alto4.xsl hocr__alto4.0.xsl
+	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/alto__hocr.xsl alto__hocr.xsl
+	cd xslt && $(LN) alto__hocr.xsl alto2.0__hocr.xsl
+	cd xslt && $(LN) alto__hocr.xsl alto2.1__hocr.xsl
+	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/hocr__text.xsl hocr__text.xsl
+	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/alto__text.xsl alto__text.xsl
 	cd xslt && $(LN) ../vendor/hOCR-to-ALTO/codes_lookup.xml codes_lookup.xml
 	cd xslt && $(LN) ../vendor/format-converters/page2hocr.xsl page__hocr.xsl
 	cd xslt && $(LN) ../vendor/format-converters/abbyy2hocr.xsl abbyy__hocr.xsl

--- a/example/Makefile
+++ b/example/Makefile
@@ -45,7 +45,7 @@ $(BASENAME).alto.page.alto : $(BASENAME).alto.page
 	$(OCR_TRANSFORM) page alto $< | $(XMLLINT) - > $@
 
 $(BASENAME).roundtrip.hocr : $(BASENAME).alto
-	$(OCR_TRANSFORM) alto2.0 hocr $< | $(XMLLINT) - > $@
+	$(OCR_TRANSFORM) alto hocr $< | $(XMLLINT) - > $@
 
 clean:
 	$(RM) $(BASENAME)*.hocr $(BASENAME)*.alto

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -28,7 +28,7 @@ ABBYY_SCHEMA_VERSIONS = 6-schema-v1 8-schema-v2 9-schema-v1 10-schema-v1
 
 HOCR2ALTO_REPO = hOCR-to-ALTO
 HOCR2ALTO_URL = https://github.com/filak/$(HOCR2ALTO_REPO)
-HOCR2ALTO_COMMITID = 43f9d9dcdd38d37071f8ef1998d377d21c9cadd2
+HOCR2ALTO_COMMITID = 7b21c4727a099117ed00c4f335aa83d0392c919f
 
 HOCR_SPEC_REPO = hocr-spec-python
 HOCR_SPEC_URL = https://github.com/kba/$(HOCR_SPEC_REPO)


### PR DESCRIPTION
This solves #95 and #81 also no special features of ALTO 3.0 or ALTO 4.0 are considered in the transformations, but this would be anyways something for upstream.
