### PR TITLE
ocr-transform: set -e before running saxon/transform scripts

### DIFF
--- a/bin/ocr-transform.sh
+++ b/bin/ocr-transform.sh
@@ -85,6 +85,8 @@ main () {
     fi
 
     # Run it
+    optstate=$(set +o)
+    set -o errexit
     transformer=${OCR_TRANSFORMERS[${from}__${to}]}
     if [[ "$transformer" = *.xsl ]];then
         script_args=("${script_args[@]}" "-xsl:$transformer")
@@ -95,6 +97,7 @@ main () {
         script_args=("$infile" "$outfile" "${script_args[@]}")
         source "$transformer" "${script_args[@]}"
     fi
+    eval "$optstate"
 }
 #}}}
 


### PR DESCRIPTION
The calls to `saxon` or the transform shell script should exit on error to prevent downstream tools from procecssing further if no/empty output was produced.

Fixes OCR-D/ocrd_fileformat#10
