### PR TITLE
Add textract2page

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "vendor/xsd-validator"]
 	path = vendor/xsd-validator
 	url = https://github.com/kba/xsd-validator.git
+[submodule "vendor/textract2page"]
+	path = vendor/textract2page
+	url = https://github.com/slub/textract2page.git

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Usage: ocr-transform [-dhLv] <from> <to> [<infile> [<outfile>]] [-- <script-args
         page page2019
         page text
         tei hocr
+        textract page
 
     Saxon options:
         Usage: see http://www.saxonica.com/documentation/index.html#!using-xsl/commandline
@@ -198,6 +199,7 @@ capable stylesheet transformer.
 | PAGEXML             | ✓    | ✓    | =       |
 | FineReader          | ✓    | -    | ✓       |
 | Google Cloud Vision | ✓    | -    | ✓       |
+| Amazon AWS Textract | -    | -    | ✓       |
 | TEI                 | ✓    | -    | -       |
 
 ## Validation
@@ -260,3 +262,5 @@ During the installation process several projects are included (in [`./vendor`](.
 * [gcv2hocr](https://github.com/dinosauria123/gcv2hocr) by Endo Michiaki, [`CC BY 4.0`](https://creativecommons.org/licenses/by/4.0/legalcode)
 * [format-converters](https://github.com/OCR-D/format-converters) by OCR-D, [`Apache 2.0`](https://github.com/OCR-D/format-converters/blob/master/LICENSE)
 * [prima-page-converter](https://github.com/PRImA-Research-Lab/prima-page-converter/) by PRImA Research Lab , [`Apache 2.0`](https://github.com/PRImA-Research-Lab/prima-page-converter/blob/master/LICENSE)
+* [page-to-alto](https://github.com/kba/page-to-alto/) by Konstantin Baierer @kba, [`Apache 2.0`](https://github.com/OCR-D/format-converters/blob/master/LICENSE)
+* [textract2page](https://github.com/slub/textract2page/) by Arne Rümmler @rue-a, [`Apache 2.0`](https://github.com/OCR-D/format-converters/blob/master/LICENSE)

--- a/bin/ocr-validate.sh
+++ b/bin/ocr-validate.sh
@@ -8,13 +8,16 @@ source "$SHAREDIR/lib.sh"
 show_usage () {
     [[ "$#" -gt 0 ]] && logerr "$@"
 
-    echo >&2 "Usage: ${0##*/} [-dhLv] <schema> <file> [<resultsFile>]
+    echo >&2 "Usage:
+${0##*/} [OPTIONS] <schema> <file> [<resultsFile>]
+${0##*/} [OPTIONS] -h|--help       Show this help, and exit
+${0##*/} [OPTIONS] -v|--version    Show version, and exit
+${0##*/} [OPTIONS] -L|--list       List available schemas, and exit
 
     Options:
-        --help    -h     Show this help
-        --version -v     Show version
         --debug   -d     Increase debug level by 1, can be repeated
-        --list    -L     List available schemas"
+
+"
     echo >&2 -e "\n${INDENT}Schemas:"
     show_schemas|sed "s/^/${INDENT}${INDENT}/"
     echo

--- a/script/transform/gcv__hocr
+++ b/script/transform/gcv__hocr
@@ -6,8 +6,8 @@ VENDORSCRIPT="$VENDORDIR/gcv2hocr/gcv2hocr"
 INFILE="$1"
 OUTFILE="$2"
 #TODO
-WIDTH=2000
-HEIGHT=2000
+WIDTH=${3:-2000}
+HEIGHT=${4:-2000}
 
 if [[ "$1" = "-" ]]; then
     INFILE="$(mktemp)"

--- a/script/transform/textract__page
+++ b/script/transform/textract__page
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENDORDIR="$(cd $SCRIPTDIR/../../vendor/; pwd)"
+INFILE="$1"
+OUTFILE="$2"
+ARGUMENTS=("${@:3}")
+
+if [[ "$1" = "-" ]]; then
+    INFILE="$(mktemp)"
+    cat >"$INFILE"
+fi
+
+if [[ "$2" = "-" ]]; then
+    OUTFILE="$(mktemp)"
+fi
+
+textract2page "${ARGUMENTS[@]:1}" -O "$OUTFILE" "$INFILE" "${ARGUMENTS[0]}"; retval="$?"
+
+if [[ "$1" = "-" ]]; then
+    rm "$INFILE"
+fi
+
+if (( retval > 0 ));then
+    rm "$OUTFILE"
+    exit $retval
+fi
+
+if [[ "$2" = "-" ]]; then
+    cat "$OUTFILE"
+    rm "$OUTFILE"
+fi

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -38,7 +38,7 @@ ALTO2PAGE_DIR = JPageConverter
 #     wget -O '$@' '$(SAXON_BROWSER_URL)'
 #}}}
 
-.PHONY: all check $(PAGE_SCHEMA_REPO) $(ABBYY_SCHEMA_REPO) gcv2hocr page-to-alto
+.PHONY: all check $(PAGE_SCHEMA_REPO) $(ABBYY_SCHEMA_REPO) gcv2hocr page-to-alto textract2page
 
 all:\
 	$(PAGE_SCHEMA_REPO)\
@@ -46,7 +46,8 @@ all:\
 	gcv2hocr \
 	saxon.jar \
 	$(ALTO2PAGE_DIR) \
-	page-to-alto
+	page-to-alto \
+	textract2page
 
 clean:
 	$(RM) $(SAXON_HE_JAR) saxon.jar
@@ -96,4 +97,7 @@ $(ALTO2PAGE_DIR): $(ALTO2PAGE_ZIP)
 	mv "JPageConverter $(ALTO2PAGE_VERSION_MAJOR_MINOR)" "$@"
 
 page-to-alto:
+	cd "$@"; $(PIP) install .
+
+textract2page:
 	cd "$@"; $(PIP) install .


### PR DESCRIPTION
In contrast to all existing transformations, https://github.com/slub/textract2page MUST know the image file, so I also tried to make it easier for the user to know what `script-args` are possible/expected:

<details><summary>example calls for `--help-args`</summary>
<p>

```
> ocr-transform hocr page --help-args
        Usage: see http://www.saxonica.com/documentation/index.html#!using-xsl/commandline
        Options available: -? -a -catalog -config -cr -diag -dtd -ea -expand -explain -export -ext -im -init -it -jit -l -lib -license -m -nogo -now -ns -o -opt -or -outval -p -quit -r -relocate -repeat -s -sa -scmin -strip -t -T -target -TB -threads -TJ -Tlevel -Tout -TP -traceout -tree -u -val -versionmsg -warnings -x -xi -xmlversion -xsd -xsdversion -xsiloc -xsl -y --?
        Use -XYZ:? for details of option XYZ
        Params: 
          param=value           Set stylesheet string parameter
          +param=filename       Set stylesheet document parameter
          ?param=expression     Set stylesheet parameter using XPath
          !param=value          Set serialization parameter

> ocr-transform gcv hocr --help-args
    Extra arguments: <width> <height>

> ocr-transform page alto --help-args
    page-to-alto options:
  -l, --log-level [OFF|ERROR|WARN|INFO|DEBUG|TRACE]
                                  Log level
  --alto-version [4.2|4.1|4.0|3.1|3.0|2.1|2.0]
                                  Choose version of ALTO-XML schema to produce
                                  (older versions may not preserve all
                                  features)
  --check-words / --no-check-words
                                  Check whether PAGE-XML contains any Words
                                  and fail if not
  --check-border / --no-check-border
                                  Check whether PAGE-XML contains Border or
                                  PrintSpace
  --skip-empty-lines / --no-skip-empty-lines
                                  Whether to omit or keep empty lines in PAGE-
                                  XML
  --trailing-dash-to-hyp / --no-trailing-dash-to-hyp
                                  Whether to add a <HYP/> element if the last
                                  word in a line ends in "-"
  --dummy-textline / --no-dummy-textline
                                  Whether to create a TextLine for regions
                                  that have TextEquiv/Unicode but no TextLine
  --dummy-word / --no-dummy-word  Whether to create a Word for TextLine that
                                  have TextEquiv/Unicode but no Word
  --textequiv-index INTEGER       If multiple textequiv, use the n-th
                                  TextEquiv by @index
  --textequiv-fallback-strategy [raise|first|last]
                                  What to do if selected TextEquiv @index is
                                  not available: 'raise' will lead to a
                                  runtime error, 'first' will use the first
                                  TextEquiv, 'last' will use the last
                                  TextEquiv on the element
  --region-order [document|reading-order|reading-order-only]
                                  Order in which to iterate over the regions
  --textline-order [document|index|textline-order]
                                  Order in which to iterate over the textlines

> ocr-transform textract page --help-args
    textract2page arguments: <image-file>
    textract2page options:

```

</p></details>