### PR TITLE
Use first bash from PATH (allows running on macOS)

### DIFF
--- a/bin/ocr-transform.sh
+++ b/bin/ocr-transform.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Default to the parent dir of this script. Overwritten by `make install`
 SHAREDIR="$(readlink -f "$(dirname "$(readlink -f "$0")")/..")"

--- a/bin/ocr-validate.sh
+++ b/bin/ocr-validate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Default to the parent dir of this script. Overwritten by `make install`
 SHAREDIR="$(readlink -f "$(dirname "$(readlink -f "$0")")/..")"

--- a/lib.sh
+++ b/lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #{{{ Logging
 if [[ -n "$COLORTERM" || "$TERM" = *color* || "$TERM" = xterm* ]];then


### PR DESCRIPTION
/bin/bash on macOS is too old (3.2.57), but can be replaced by a recent bash version from Homebrew.